### PR TITLE
broken link for the rnr.dll

### DIFF
--- a/scripts/installbench.ps1
+++ b/scripts/installbench.ps1
@@ -17,6 +17,6 @@ Invoke-WebRequest -Uri "https://github.com/atlarge-research/librnr/releases/late
 
 # Download rnr.dll
 Write-Output "downloading library..."
-Invoke-WebRequest -Uri "https://github.com/atlarge-research/librnr/releases/latest/download/librnr.dll" -OutFile $rnrFilePath
+Invoke-WebRequest -Uri "https://github.com/atlarge-research/librnr/releases/latest/download/rnr.dll" -OutFile $rnrFilePath
 
 Write-Output "done!"


### PR DESCRIPTION
The initial link was trying to download `librnr.dll` instead of `rnr.dll`. Fixed that and added the `latest` version in the link